### PR TITLE
Created SpecUtil to handle common API request config and common assertions.

### DIFF
--- a/src/test/java/com/api/tests/CountAPITest.java
+++ b/src/test/java/com/api/tests/CountAPITest.java
@@ -6,11 +6,9 @@ import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
 
 import com.api.constants.Role;
-import com.api.utils.AuthTokenProvider;
-import com.api.utils.ConfigManager;
+import com.api.utils.SpecUtil;
 
 import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class CountAPITest {
@@ -20,22 +18,11 @@ public class CountAPITest {
 	{
 		RestAssured
 		.given()
-		.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-		.header("Authorization",AuthTokenProvider.getToken(Role.FD))
-		.and()
-		.accept(ContentType.JSON)
-		.log().uri()
-		.log().method()
-		.log().body()
-		.log().headers()
+		.spec(SpecUtil.requestSpecWithAuth(Role.FD))
 		.when()
 		.get(File.separator+"dashboard"+File.separator+"count")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.and()
-		.time(Matchers.lessThan(1000L))
+		.spec(SpecUtil.responseSpec_OK())
 		.and()
 		.body("message",Matchers.equalTo("Success"))
 		.and()
@@ -54,18 +41,11 @@ public class CountAPITest {
 	public void countAPITest_missingAuthToken()
 	{
 		RestAssured.given()
-		.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-		.accept(ContentType.JSON)
-		.log().uri()
-		.log().method()
-		.log().body()
-		.log().headers()
+		.spec(SpecUtil.requestSpec())
 		.when()
 		.get(File.separator+"dashboard"+File.separator+"count")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/tests/LoginAPITest.java
+++ b/src/test/java/com/api/tests/LoginAPITest.java
@@ -8,9 +8,8 @@ import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
 
 import com.api.pojo.UserCredentials;
-import com.api.utils.ConfigManager;
+import com.api.utils.SpecUtil;
 
-import io.restassured.http.ContentType;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class LoginAPITest {
@@ -22,27 +21,14 @@ public class LoginAPITest {
 		
 		UserCredentials userCredentials = new UserCredentials("iamfd", "password");
 		
-		given()
-		.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-		.contentType(ContentType.JSON)
-		.and()
-		.accept(ContentType.JSON)
-		.and()
-		.body(userCredentials)
-		.log().uri()
-		.log().method()
-		.log().headers()
-		.log().body()
+		given().spec(SpecUtil.requestSpec(userCredentials))
 		.when()
 		.post("/login")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.and()
-		.time(Matchers.lessThan(1000L))
+		.spec(SpecUtil.responseSpec_OK())
 		.and()
 		.body("message", Matchers.equalTo("Success"))
+		.and()
 		.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("responseSchema/loginResponseSchema.json"));
 		
 		

--- a/src/test/java/com/api/tests/MasterAPITest.java
+++ b/src/test/java/com/api/tests/MasterAPITest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.Test;
 import com.api.constants.Role;
 import com.api.utils.AuthTokenProvider;
 import com.api.utils.ConfigManager;
+import com.api.utils.SpecUtil;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -20,27 +21,11 @@ public class MasterAPITest {
 	{
 		RestAssured
 		.given()
-		.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-		.header("Authorization",AuthTokenProvider.getToken(Role.FD))
-		.and()
-		.and()
-		.contentType("")
-		.and()
-		.accept(ContentType.JSON)
-		.and()
-		.log().uri()
-		.log().body()
-		.log().method()
-		.log().headers()
+		.spec(SpecUtil.requestSpecWithAuth(Role.FD))
 		.when()
 		.post(File.separator+"master")
 		.then()
-		.log().all()
-		.and()
-		.statusCode(200)
-		.and()
-		.time(Matchers.lessThan(1000L))
+		.spec(SpecUtil.responseSpec_OK())
 		.and()
 		.body("message",Matchers.equalTo("Success"))
 		.and()
@@ -69,25 +54,11 @@ public class MasterAPITest {
 	{
 		RestAssured
 		.given()
-		.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-		.header("Authorization","")
-		.and()
-		.and()
-		.contentType("")
-		.and()
-		.accept(ContentType.JSON)
-		.and()
-		.log().uri()
-		.log().body()
-		.log().method()
-		.log().headers()
+		.spec(SpecUtil.requestSpec())
 		.when()
 		.post(File.separator+"master")
 		.then()
-		.log().all()
-		.and()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/tests/UserDetailsAPITest.java
+++ b/src/test/java/com/api/tests/UserDetailsAPITest.java
@@ -1,17 +1,14 @@
 package com.api.tests;
 
+import java.io.File;
 import java.io.IOException;
 
-import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
 
 import com.api.constants.Role;
-import com.api.utils.AuthTokenProvider;
-import com.api.utils.ConfigManager;
+import com.api.utils.SpecUtil;
 
 import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class UserDetailsAPITest {
@@ -21,28 +18,16 @@ public class UserDetailsAPITest {
 	public void userDetailsAPITest() throws IOException
 	{
 		
-		Header authHeader = new Header("Authorization",AuthTokenProvider.getToken(Role.FD));
 		
 		RestAssured
 		.given()
-		.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-		.header(authHeader)
-		.and()
-		.accept(ContentType.JSON)
-		.log().uri()
-		.log().method()
-		.log().body()
-		.log().headers()
+		.spec(SpecUtil.requestSpecWithAuth(Role.FD))
 		.when()
-		.get("/userdetails")
+		.get(File.separator+"userdetails")
 		.then()
-		.log().all()	
-		.statusCode(200)
+		.spec(SpecUtil.responseSpec_OK())
 		.and()
-		.time(Matchers.lessThan(1000L))
-		.and()
-		.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("responseSchema/userDetailsResponseSchema.json"));
+		.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("responseSchema"+File.separator+"userDetailsResponseSchema.json"));
 	}
 
 }

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,142 @@
+package com.api.utils;
+
+import org.hamcrest.Matchers;
+
+import com.api.constants.Role;
+import com.api.pojo.UserCredentials;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+public class SpecUtil {
+	
+
+	//GET and DEL
+	public static RequestSpecification requestSpec()
+	{
+		//to take care of the common request sections (methods)
+		
+	   RequestSpecification request = new RequestSpecBuilder()
+	   .setBaseUri(ConfigManager.getProperty("BASE_URI"))
+	   .and()
+	   .setContentType(ContentType.JSON)
+	   .and()
+	   .setAccept(ContentType.JSON)
+	   .and()
+	   .log(LogDetail.URI)
+	   .log(LogDetail.METHOD)
+	   .log(LogDetail.HEADERS)
+	   .log(LogDetail.BODY)
+	   
+	   .build();
+	   
+	   return request;
+	}
+	
+	//POST, PUT, and PATCH
+	public static RequestSpecification requestSpec(Object payload)
+	{
+		//to take care of the common request sections (methods)
+		
+	   RequestSpecification request = new RequestSpecBuilder()
+	   .setBaseUri(ConfigManager.getProperty("BASE_URI"))
+	   .and()
+	   .setContentType(ContentType.JSON)
+	   .and()
+	   .setAccept(ContentType.JSON)
+	   .and()
+	   .log(LogDetail.URI)
+	   .log(LogDetail.METHOD)
+	   .log(LogDetail.HEADERS)
+	   .log(LogDetail.BODY)
+	   .and()
+	   .setBody(payload)
+	   
+	   .build();
+	   
+	   return request;
+	}
+	
+	public static ResponseSpecification responseSpec_OK()
+	{
+		ResponseSpecification responseSpecification =new ResponseSpecBuilder()
+		.expectStatusCode(200)
+		.expectResponseTime(Matchers.lessThan(1000L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+		
+	}
+	
+	public static RequestSpecification requestSpecWithAuth(Role role)
+	{
+		RequestSpecification request = new RequestSpecBuilder()
+				   .setBaseUri(ConfigManager.getProperty("BASE_URI"))
+				   .and()
+				   .setContentType(ContentType.JSON)
+				   .and()
+				   .setAccept(ContentType.JSON)
+				   .and()
+				   .addHeader("Authorization",AuthTokenProvider.getToken(role))
+				   .log(LogDetail.URI)
+				   .log(LogDetail.METHOD)
+				   .log(LogDetail.HEADERS)
+				   .log(LogDetail.BODY)
+				   .build();
+				   
+				   return request;
+	}
+	
+	
+	public static ResponseSpecification responseSpec_JSON(int statusCode)
+	{
+		ResponseSpecification responseSpecification =new ResponseSpecBuilder()
+	    .expectContentType(ContentType.JSON)
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(1000L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+		
+	}
+	
+	public static ResponseSpecification responseSpec_TEXT(int statusCode)
+	{
+		ResponseSpecification responseSpecification =new ResponseSpecBuilder()
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(1000L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+		
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	 
+}


### PR DESCRIPTION
SpecUtil is consisting of common RequestSpecBuilder and ResponseSpecBuilder. These utils methods has reduced the boiler plate code in our API tests, and also reduced the number of lines. Making test code smaller and maintainable.